### PR TITLE
Updating github link to be more clear

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
     <div class="footer-container">
         <div class="column">
             <p>© 2016 Nike, Inc. All Rights Reserved.</p>
-            <p>You can view the source on <a target="_blank" onclick="trackOutboundLink('https://github.com/nike-inc/cerberus')" href="https://github.com/nike-inc/cerberus">Github</a>.</p>
+            <p>View source code for this site on <a target="_blank" onclick="trackOutboundLink('https://github.com/nike-inc/cerberus')" href="https://github.com/nike-inc/cerberus">Github</a>.</p>
         </div>
         <div class="column">
             <h4><a target="_blank" onclick="trackOutboundLink('http://about.nike.com/')" href="http://about.nike.com/">About Nike</a></h4>


### PR DESCRIPTION
I noticed in the analytics people were clicking this link.  My guess is they were thinking they were navigating to the source code for Cerberus rather than the source code for this website.

(I choose wording that would still fit on a single line without wrapping)