### PR TITLE
Several updates related to open sourcing the Ruby client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _site
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 .idea
+*.iml
 
 # User-specific stuff:
 .idea/workspace.xml

--- a/_data/components_data.yml
+++ b/_data/components_data.yml
@@ -105,7 +105,7 @@
     description: A Ruby client for interacting with the Cerberus <a href="../docs/architecture/rest-api">REST API</a>.
     language: ruby
     url: https://github.com/Nike-Inc/cerberus-ruby-client
-    public: false
+    public: true
     maintainer: Nike, Inc
     maintainer_url: http://engineering.nike.com/
 
@@ -152,15 +152,5 @@
     language: multi
     url: https://github.com/Nike-Inc/cerberus-vault-puppet-module
     public: true
-    maintainer: Nike, Inc
-    maintainer_url: http://engineering.nike.com/
-
-  - name: Token Fetcher
-    description: >
-      A Java CLI to use on the command line of an EC2 instance to automatically fetch a
-      <a href="../docs/architecture/vault">Vault</a> token.  This is useful for Bash scripting.
-    language: java
-    url:
-    public: false
     maintainer: Nike, Inc
     maintainer_url: http://engineering.nike.com/

--- a/_posts/2017-02-08-ruby-client.md
+++ b/_posts/2017-02-08-ruby-client.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: Ruby Client Released
+date:   2017-02-08 12:00:00 -0700
+categories: news
+---
+
+The Cerberus Ruby Client has been open sourced.
+
+The Ruby client currently supports read-only operations against Cerberus so it is slightly less complete than some of
+the other clients.
+
+More information is available in the <a target="_blank" onclick="trackOutboundLink('https://github.com/Nike-Inc/cerberus-ruby-client/')" href="https://github.com/Nike-Inc/cerberus-ruby-client/">Github repo</a>.

--- a/docs/contributing/roadmap.md
+++ b/docs/contributing/roadmap.md
@@ -18,7 +18,6 @@ title: Roadmap
    -  Update permissions management: move from account / name to ARN (easier to use, eliminates customer confusion that comes up occasionally)
    -  KPIs - can we capture more stats on usage
 -  Create automated integration test suite to fully validate Cerberus functionality
--  Finish open sourcing all components listed on the [components page](../components) that are not yet public
 -  SOX/PCI compliance - ensure the proper auditing capabilities are in place to support compliance, i.e. change tracking, etc.
 -  Ubuntu - remove tight coupling to particular release (14.04LTS) or at least upgrade to 16LTS.
 -  Stay up-to-date with latest versions of Vault and Consul

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -82,6 +82,7 @@ Use one of the clients:
 * <a target="_blank" onclick="trackOutboundLink('https://github.com/Nike-Inc/cerberus-archaius-client')" href="https://github.com/Nike-Inc/cerberus-archaius-client">Java Archaius Polling Client</a> (generally preferred for 
   companies using [Archaius](archaius))
 * <a target="_blank" onclick="trackOutboundLink('https://github.com/Nike-Inc/cerberus-java-client')" href="https://github.com/Nike-Inc/cerberus-node-client">Node Client</a>
+* <a target="_blank" onclick="trackOutboundLink('https://github.com/Nike-Inc/cerberus-ruby-client')" href="https://github.com/Nike-Inc/cerberus-ruby-client">Ruby Client</a>
 
 Don't see your desired client? Cerberus has a REST API. You 
 can [contribute](../contributing/how-to-contribute) a new client or use the [REST API](../architecture/rest-api) directly.


### PR DESCRIPTION
- News article
- Quick start guide
- Components page 
- Roadmap

Also, removed token fetcher from components page since it wasn't clear it is that useful or that we'd do anything with it.